### PR TITLE
classification impute for 1 NA value

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^miceRanger\.Rproj$
+^\.Rproj\.user$

--- a/.Rhistory
+++ b/.Rhistory
@@ -1,0 +1,2 @@
+library(miceRanger)
+library(miceRanger)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.Rproj.user

--- a/R/imputeFromPred.R
+++ b/R/imputeFromPred.R
@@ -8,18 +8,27 @@ imputeFromPred <- function(
   , priorPreds
 )
 {
-  
+
   # pred - The output from the model of the samples you want to impute
   # modelType - Classification or Regression
   # valueSelector - meanMatch or value
   # meanMatchCandidates - Integer
   # prior - Unaltered values of original nonmissing data
   # priorPreds model predictions associated with prior
-  
+
   if (valueSelector == "value") {
     return(pred)
   } else {
     if (modelType == "Classification") {
+
+      # boundary case: if a categorical variables has only one missing
+      # value, the pred object will be a vector instead of a matrix.
+      if(!is.matrix(pred)){
+        pred_names <- names(pred)
+        pred <- matrix(pred, nrow = 1)
+        colnames(pred) <- pred_names
+      }
+
       lvls <- colnames(pred)
       return(apply(pred,MARGIN=1,function(x) sample(lvls,prob=x,size=1)))
     } else if (modelType == "Regression") {

--- a/miceRanger.Rproj
+++ b/miceRanger.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Thanks for this package - it is incredibly fast and so useful. 

I noticed there is a boundary case that causes an issue. Specifically, if a categorical variable has only one missing value, the `pred` object in `imputeFromPred` will be a vector instead of a matrix, and `apply()` will be upset about a `NULL` dimension. A fix is implemented in this PR.